### PR TITLE
fix(security): address access control, XSS, injection, and cache issues

### DIFF
--- a/src/Controller/LlmSitemapController.php
+++ b/src/Controller/LlmSitemapController.php
@@ -109,7 +109,7 @@ final class LlmSitemapController extends ControllerBase {
 
     $cacheMetadata = new CacheableMetadata();
     $cacheMetadata->addCacheTags(['llm_content:list', 'node_list', 'path_alias_list']);
-    $cacheMetadata->addCacheContexts(['user.permissions']);
+    $cacheMetadata->addCacheContexts(['user.permissions', 'user.node_grants:view']);
     $response->addCacheableDependency($cacheMetadata);
     $response->addCacheableDependency($config);
 

--- a/src/Controller/LlmsTxtController.php
+++ b/src/Controller/LlmsTxtController.php
@@ -65,7 +65,10 @@ final class LlmsTxtController extends ControllerBase {
           // Pre-fetch all stored markdown for this batch in one query.
           $batchMarkdown = $this->markdownConverter->getStoredMarkdownBatch($batch, $langcode);
           foreach ($nodes as $node) {
-            $title = $node->label() ?? 'Untitled';
+            // Sanitize title for markdown link safety: strip HTML and escape
+            // characters that could break markdown link syntax.
+            $title = strip_tags($node->label() ?? 'Untitled');
+            $title = str_replace(['[', ']'], ['(', ')'], $title);
             $url = Url::fromRoute('llm_content.markdown_view', ['node' => $node->id()])->toString();
             $description = '';
             if ($node->hasField('body') && !$node->get('body')->isEmpty()) {
@@ -102,7 +105,7 @@ final class LlmsTxtController extends ControllerBase {
 
     $cacheMetadata = new CacheableMetadata();
     $cacheMetadata->addCacheTags(['llm_content:list', 'node_list', 'path_alias_list']);
-    $cacheMetadata->addCacheContexts(['user.permissions']);
+    $cacheMetadata->addCacheContexts(['user.permissions', 'user.node_grants:view']);
     $response->addCacheableDependency($cacheMetadata);
     $response->addCacheableDependency($config);
     $response->addCacheableDependency($siteConfig);
@@ -124,7 +127,7 @@ final class LlmsTxtController extends ControllerBase {
 
     $cacheMetadata = new CacheableMetadata();
     $cacheMetadata->addCacheTags(['llm_content:list', 'node_list']);
-    $cacheMetadata->addCacheContexts(['user.permissions']);
+    $cacheMetadata->addCacheContexts(['user.permissions', 'user.node_grants:view']);
     $response->addCacheableDependency($cacheMetadata);
     $response->addCacheableDependency($config);
 

--- a/src/Controller/LlmsTxtController.php
+++ b/src/Controller/LlmsTxtController.php
@@ -7,7 +7,6 @@ namespace Drupal\llm_content\Controller;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Url;
 use Drupal\llm_content\Service\MarkdownConverterInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,7 +18,6 @@ final class LlmsTxtController extends ControllerBase {
 
   public function __construct(
     protected MarkdownConverterInterface $markdownConverter,
-    protected LanguageManagerInterface $languageManager,
   ) {}
 
   /**
@@ -28,7 +26,6 @@ final class LlmsTxtController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get(MarkdownConverterInterface::class),
-      $container->get('language_manager'),
     );
   }
 
@@ -59,7 +56,7 @@ final class LlmsTxtController extends ControllerBase {
 
       if (!empty($nids)) {
         $output .= "## Content\n\n";
-        $langcode = $this->languageManager->getCurrentLanguage()->getId();
+        $langcode = $this->languageManager()->getCurrentLanguage()->getId();
         foreach (array_chunk($nids, 50) as $batch) {
           $nodes = $nodeStorage->loadMultiple($batch);
           // Pre-fetch all stored markdown for this batch in one query.

--- a/src/Service/MarkdownConverter.php
+++ b/src/Service/MarkdownConverter.php
@@ -116,9 +116,13 @@ final class MarkdownConverter implements MarkdownConverterInterface {
     }
     $frontmatter .= "---\n\n";
 
-    // Strip HTML tags from the title for the heading to prevent XSS when
-    // consumers render the markdown back to HTML.
+    // Sanitize the title for the H1 heading: strip HTML, control chars,
+    // and brackets that could be used to inject markdown links (e.g. a
+    // node title of `[text](javascript:alert(1))` would otherwise land
+    // verbatim in the heading and execute when rendered back to HTML).
     $headingTitle = strip_tags($node->label() ?? '');
+    $headingTitle = preg_replace('/[\x00-\x1f\x7f]/', '', $headingTitle) ?? $headingTitle;
+    $headingTitle = str_replace(['[', ']'], ['(', ')'], $headingTitle);
     $fullMarkdown = $frontmatter . '# ' . $headingTitle . "\n\n" . trim($markdown);
 
     // Store in database.
@@ -346,13 +350,17 @@ final class MarkdownConverter implements MarkdownConverterInterface {
       ->execute();
 
     if (!empty($nids)) {
-      // Fetch stored markdown for these access-checked nids.
-      $results = $this->database->select('llm_content_markdown', 'm')
-        ->fields('m', ['markdown'])
-        ->condition('nid', $nids, 'IN')
-        ->orderBy('nid', 'ASC')
-        ->execute()
-        ->fetchCol();
+      // Fetch stored markdown for the access-checked nids. Join on
+      // node_field_data with default_langcode = 1 so multilingual nodes
+      // only contribute their canonical translation — without this we
+      // would emit one copy per language stored in llm_content_markdown.
+      $query = $this->database->select('llm_content_markdown', 'm');
+      $query->innerJoin('node_field_data', 'n', 'n.nid = m.nid AND n.langcode = m.langcode');
+      $query->fields('m', ['markdown']);
+      $query->condition('m.nid', $nids, 'IN');
+      $query->condition('n.default_langcode', 1);
+      $query->orderBy('m.nid', 'ASC');
+      $results = $query->execute()->fetchCol();
 
       foreach ($results as $markdown) {
         $output .= $markdown . "\n\n---\n\n";

--- a/src/Service/MarkdownConverter.php
+++ b/src/Service/MarkdownConverter.php
@@ -99,13 +99,16 @@ final class MarkdownConverter implements MarkdownConverterInterface {
 
     // Build frontmatter.
     $alias = $this->aliasManager->getAliasByPath('/node/' . $node->id());
-    $title = $node->label() ?? '';
+    $title = strip_tags($node->label() ?? '');
     // Sanitize title for YAML safety: escape quotes, strip control characters.
     $title = preg_replace('/[\x00-\x1f\x7f]/', '', $title) ?? $title;
     $title = str_replace(['\\', '"'], ['\\\\', '\\"'], $title);
+    // Sanitize alias for YAML safety: strip control chars and quote.
+    $alias = preg_replace('/[\x00-\x1f\x7f]/', '', $alias) ?? $alias;
+    $alias = str_replace(['\\', '"'], ['\\\\', '\\"'], $alias);
     $frontmatter = "---\n";
     $frontmatter .= 'title: "' . $title . "\"\n";
-    $frontmatter .= 'url: ' . $alias . "\n";
+    $frontmatter .= 'url: "' . $alias . "\"\n";
     $frontmatter .= 'type: ' . $node->bundle() . "\n";
     $frontmatter .= 'date: ' . $this->dateFormatter->format($node->getCreatedTime(), 'custom', 'Y-m-d') . "\n";
     if ($node->getRevisionCreationTime()) {
@@ -113,7 +116,10 @@ final class MarkdownConverter implements MarkdownConverterInterface {
     }
     $frontmatter .= "---\n\n";
 
-    $fullMarkdown = $frontmatter . '# ' . ($node->label() ?? '') . "\n\n" . trim($markdown);
+    // Strip HTML tags from the title for the heading to prevent XSS when
+    // consumers render the markdown back to HTML.
+    $headingTitle = strip_tags($node->label() ?? '');
+    $fullMarkdown = $frontmatter . '# ' . $headingTitle . "\n\n" . trim($markdown);
 
     // Store in database.
     $this->database->merge('llm_content_markdown')
@@ -330,18 +336,27 @@ final class MarkdownConverter implements MarkdownConverterInterface {
       return $output;
     }
 
-    // Join with node_field_data for access control and type filtering.
-    $query = $this->database->select('llm_content_markdown', 'm');
-    $query->innerJoin('node_field_data', 'n', 'm.nid = n.nid AND m.langcode = n.langcode');
-    $query->fields('m', ['markdown']);
-    $query->condition('n.status', 1);
-    $query->condition('n.type', $enabledTypes, 'IN');
-    $query->orderBy('m.nid', 'ASC');
-    $query->range(0, 500);
-    $results = $query->execute()->fetchCol();
+    // Use entity query with access check to enforce node access restrictions.
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+    $nids = $nodeStorage->getQuery()
+      ->condition('status', 1)
+      ->condition('type', $enabledTypes, 'IN')
+      ->accessCheck(TRUE)
+      ->sort('nid', 'ASC')
+      ->execute();
 
-    foreach ($results as $markdown) {
-      $output .= $markdown . "\n\n---\n\n";
+    if (!empty($nids)) {
+      // Fetch stored markdown for these access-checked nids.
+      $results = $this->database->select('llm_content_markdown', 'm')
+        ->fields('m', ['markdown'])
+        ->condition('nid', $nids, 'IN')
+        ->orderBy('nid', 'ASC')
+        ->execute()
+        ->fetchCol();
+
+      foreach ($results as $markdown) {
+        $output .= $markdown . "\n\n---\n\n";
+      }
     }
 
     return $output;

--- a/tests/src/Unit/LlmsTxtControllerSecurityTest.php
+++ b/tests/src/Unit/LlmsTxtControllerSecurityTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\llm_content\Unit;
+
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\llm_content\Controller\LlmsTxtController;
+use Drupal\llm_content\Service\MarkdownConverterInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests security fixes in LlmsTxtController.
+ *
+ * Covers PR #24: user.node_grants:view cache context on both endpoints.
+ *
+ * @group llm_content
+ * @coversDefaultClass \Drupal\llm_content\Controller\LlmsTxtController
+ */
+class LlmsTxtControllerSecurityTest extends TestCase {
+
+  /**
+   * The controller under test.
+   */
+  protected LlmsTxtController $controller;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // llm_content.settings with no enabled types — keeps llmsTxt() simple
+    // (skips the entity query branch entirely).
+    $llmSettings = $this->createMock(ImmutableConfig::class);
+    $llmSettings->method('get')->willReturnCallback(
+      static fn (string $k) => match ($k) {
+        'enabled_content_types' => [],
+        default => NULL,
+      },
+    );
+    $llmSettings->method('getCacheContexts')->willReturn([]);
+    $llmSettings->method('getCacheTags')->willReturn(['config:llm_content.settings']);
+    $llmSettings->method('getCacheMaxAge')->willReturn(-1);
+
+    $siteSettings = $this->createMock(ImmutableConfig::class);
+    $siteSettings->method('get')->willReturnCallback(
+      static fn (string $k) => match ($k) {
+        'name' => 'Site',
+        default => '',
+      },
+    );
+    $siteSettings->method('getCacheContexts')->willReturn([]);
+    $siteSettings->method('getCacheTags')->willReturn(['config:system.site']);
+    $siteSettings->method('getCacheMaxAge')->willReturn(-1);
+
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturnCallback(
+      static fn (string $name) => $name === 'system.site' ? $siteSettings : $llmSettings,
+    );
+
+    // Cache contexts manager accepts whatever tokens the controller asks for.
+    $cacheContextsManager = $this->createMock(CacheContextsManager::class);
+    $cacheContextsManager->method('assertValidTokens')->willReturn(TRUE);
+
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $configFactory);
+    $container->set('cache_contexts_manager', $cacheContextsManager);
+    \Drupal::setContainer($container);
+
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+    $languageManager = $this->createMock(LanguageManagerInterface::class);
+    $languageManager->method('getCurrentLanguage')->willReturn($language);
+
+    $markdownConverter = $this->createMock(MarkdownConverterInterface::class);
+    $markdownConverter->method('generateFullText')->willReturn('# Site');
+
+    $this->controller = new LlmsTxtController($markdownConverter, $languageManager);
+  }
+
+  /**
+   * Llms.txt response must vary on node grants to prevent cross-user leakage.
+   *
+   * Since the controller filters nodes with accessCheck(TRUE), the
+   * response must vary by the user's node grant context — otherwise a
+   * cached response from a privileged user could be served to an
+   * unprivileged one.
+   *
+   * @covers ::llmsTxt
+   */
+  public function testLlmsTxtAddsNodeGrantsCacheContext(): void {
+    $response = $this->controller->llmsTxt();
+
+    $this->assertContains(
+      'user.node_grants:view',
+      $response->getCacheableMetadata()->getCacheContexts(),
+    );
+  }
+
+  /**
+   * Llms-full.txt response must vary on node grants for the same reason.
+   *
+   * @covers ::llmsFullTxt
+   */
+  public function testLlmsFullTxtAddsNodeGrantsCacheContext(): void {
+    $response = $this->controller->llmsFullTxt();
+
+    $this->assertContains(
+      'user.node_grants:view',
+      $response->getCacheableMetadata()->getCacheContexts(),
+    );
+  }
+
+}

--- a/tests/src/Unit/LlmsTxtControllerSecurityTest.php
+++ b/tests/src/Unit/LlmsTxtControllerSecurityTest.php
@@ -8,8 +8,6 @@ use Drupal\Core\Cache\Context\CacheContextsManager;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\llm_content\Controller\LlmsTxtController;
 use Drupal\llm_content\Service\MarkdownConverterInterface;
 use PHPUnit\Framework\TestCase;
@@ -73,15 +71,14 @@ class LlmsTxtControllerSecurityTest extends TestCase {
     $container->set('cache_contexts_manager', $cacheContextsManager);
     \Drupal::setContainer($container);
 
-    $language = $this->createMock(LanguageInterface::class);
-    $language->method('getId')->willReturn('en');
-    $languageManager = $this->createMock(LanguageManagerInterface::class);
-    $languageManager->method('getCurrentLanguage')->willReturn($language);
-
     $markdownConverter = $this->createMock(MarkdownConverterInterface::class);
     $markdownConverter->method('generateFullText')->willReturn('# Site');
 
-    $this->controller = new LlmsTxtController($markdownConverter, $languageManager);
+    // Note: ControllerBase::languageManager() pulls from the container
+    // lazily, but enabled_content_types is empty here so llmsTxt()
+    // never enters the branch that calls it. No language_manager
+    // service registration needed.
+    $this->controller = new LlmsTxtController($markdownConverter);
   }
 
   /**

--- a/tests/src/Unit/MarkdownConverterSecurityTest.php
+++ b/tests/src/Unit/MarkdownConverterSecurityTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\llm_content\Unit;
+
+use Drupal\Core\Entity\EntityViewBuilderInterface;
+use League\HTMLToMarkdown\HtmlConverter;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\Merge;
+use Drupal\Core\Database\Query\SelectInterface;
+use Drupal\Core\Database\StatementInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\llm_content\Service\MarkdownConverter;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests security fixes in MarkdownConverter.
+ *
+ * Covers PR #24: title XSS sanitization, YAML frontmatter injection
+ * defense, and access-checked entity query in generateFullText().
+ *
+ * @group llm_content
+ * @coversDefaultClass \Drupal\llm_content\Service\MarkdownConverter
+ */
+class MarkdownConverterSecurityTest extends TestCase {
+
+  /**
+   * Builds a MarkdownConverter with fully-mocked dependencies for convert().
+   *
+   * The provided $renderedHtml is what renderer->renderInIsolation() returns
+   * — i.e. the simulated rendered node markup that convert() will then
+   * strip + convert to markdown.
+   *
+   * @return array{MarkdownConverter, NodeInterface}
+   *   The converter and a mock node ready for convert().
+   */
+  protected function buildConverterForConvert(
+    string $renderedHtml = '<p>Body content.</p>',
+    string $label = 'Test',
+    string $alias = '/test',
+  ): array {
+    $reflection = new \ReflectionClass(MarkdownConverter::class);
+    $converter = $reflection->newInstanceWithoutConstructor();
+
+    // htmlConverter is normally constructed in __construct().
+    $htmlConverter = new HtmlConverter([
+      'strip_tags' => TRUE,
+      'remove_nodes' => 'script style iframe nav header footer aside',
+      'header_style' => 'atx',
+    ]);
+    $this->setProp($reflection, $converter, 'htmlConverter', $htmlConverter);
+    $this->setProp($reflection, $converter, 'logger', $this->createMock(LoggerInterface::class));
+
+    // configFactory: convert() reads view_mode from llm_content.settings.
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')->willReturnCallback(
+      static fn (string $k) => $k === 'view_mode' ? 'full' : NULL
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($settings);
+    $this->setProp($reflection, $converter, 'configFactory', $configFactory);
+
+    // entityTypeManager: convert() calls getViewBuilder('node')->view().
+    $viewBuilder = $this->createMock(EntityViewBuilderInterface::class);
+    $viewBuilder->method('view')->willReturn(['#markup' => $renderedHtml]);
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $etm->method('getViewBuilder')->with('node')->willReturn($viewBuilder);
+    $this->setProp($reflection, $converter, 'entityTypeManager', $etm);
+
+    // renderer: returns the canned HTML.
+    $renderer = $this->createMock(RendererInterface::class);
+    $renderer->method('renderInIsolation')->willReturn($renderedHtml);
+    $this->setProp($reflection, $converter, 'renderer', $renderer);
+
+    // aliasManager: returns the canned alias.
+    $aliasManager = $this->createMock(AliasManagerInterface::class);
+    $aliasManager->method('getAliasByPath')->willReturn($alias);
+    $this->setProp($reflection, $converter, 'aliasManager', $aliasManager);
+
+    // dateFormatter & time: cheap stubs.
+    $dateFormatter = $this->createMock(DateFormatterInterface::class);
+    $dateFormatter->method('format')->willReturn('2026-01-01');
+    $this->setProp($reflection, $converter, 'dateFormatter', $dateFormatter);
+    $time = $this->createMock(TimeInterface::class);
+    $time->method('getRequestTime')->willReturn(1700000000);
+    $this->setProp($reflection, $converter, 'time', $time);
+
+    // database->merge() chain — swallow the write.
+    $merge = $this->createMock(Merge::class);
+    $merge->method('keys')->willReturnSelf();
+    $merge->method('fields')->willReturnSelf();
+    $merge->method('execute')->willReturn(Merge::STATUS_INSERT);
+    $database = $this->createMock(Connection::class);
+    $database->method('merge')->willReturn($merge);
+    $this->setProp($reflection, $converter, 'database', $database);
+
+    // Node mock.
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('id')->willReturn('1');
+    $node->method('bundle')->willReturn('article');
+    $node->method('label')->willReturn($label);
+    $node->method('language')->willReturn($language);
+    $node->method('getCreatedTime')->willReturn(1700000000);
+    $node->method('getRevisionCreationTime')->willReturn(1700000000);
+
+    return [$converter, $node];
+  }
+
+  /**
+   * Sets a protected/private property via reflection.
+   */
+  protected function setProp(\ReflectionClass $reflection, object $obj, string $name, mixed $value): void {
+    $prop = $reflection->getProperty($name);
+    $prop->setAccessible(TRUE);
+    $prop->setValue($obj, $value);
+  }
+
+  /**
+   * HTML tags in node titles must be stripped from the YAML title field.
+   *
+   * @covers ::convert
+   */
+  public function testConvertStripsHtmlFromYamlTitle(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      label: 'Hello <script>alert(1)</script> World',
+    );
+
+    $output = $converter->convert($node);
+
+    $this->assertStringContainsString('title: "Hello alert(1) World"', $output);
+    $this->assertStringNotContainsString('<script>', $output);
+  }
+
+  /**
+   * HTML tags in node titles must be stripped from the markdown H1.
+   *
+   * @covers ::convert
+   */
+  public function testConvertStripsHtmlFromHeadingTitle(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      label: 'Title with <img src=x onerror=alert(1)> tag',
+    );
+
+    $output = $converter->convert($node);
+
+    $this->assertMatchesRegularExpression('/^# Title with  tag\n/m', $output);
+    $this->assertStringNotContainsString('onerror', $output);
+  }
+
+  /**
+   * Double quotes and backslashes in titles must be YAML-escaped.
+   *
+   * Without escaping, a title containing `"` breaks the YAML
+   * `title: "..."` value and could inject arbitrary frontmatter fields.
+   *
+   * @covers ::convert
+   */
+  public function testConvertEscapesYamlQuotesInTitle(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      label: 'He said "hi" \\o/',
+    );
+
+    $output = $converter->convert($node);
+
+    // Backslash → \\, double-quote → \".
+    $this->assertStringContainsString('title: "He said \\"hi\\" \\\\o/"', $output);
+  }
+
+  /**
+   * Control characters (including newlines) must be stripped from the title.
+   *
+   * A newline in the unescaped title would break out of the title: line
+   * and inject arbitrary YAML keys.
+   *
+   * @covers ::convert
+   */
+  public function testConvertStripsControlCharsFromTitle(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      label: "Innocent\ninjected: true",
+    );
+
+    $output = $converter->convert($node);
+
+    // The newline (and the injected key indentation) collapses — the
+    // injected `injected: true` key must NOT appear as its own YAML line.
+    $this->assertStringContainsString('title: "Innocentinjected: true"', $output);
+    $this->assertDoesNotMatchRegularExpression('/^injected: true$/m', $output);
+  }
+
+  /**
+   * Path aliases must be quoted and sanitized in the url frontmatter field.
+   *
+   * Bare unquoted aliases containing newlines could inject frontmatter
+   * keys. The fix quotes the url: value and strips control characters.
+   *
+   * @covers ::convert
+   */
+  public function testConvertQuotesAndSanitizesUrlAlias(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      alias: "/legit\ninjected: true",
+    );
+
+    $output = $converter->convert($node);
+
+    // Url value is quoted, and the injected newline+key is stripped.
+    $this->assertStringContainsString('url: "/legitinjected: true"', $output);
+    $this->assertDoesNotMatchRegularExpression('/^injected: true$/m', $output);
+  }
+
+  /**
+   * Backslashes and double-quotes in aliases must be YAML-escaped.
+   *
+   * @covers ::convert
+   */
+  public function testConvertEscapesYamlQuotesInAlias(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      alias: '/path/with"quote\\back',
+    );
+
+    $output = $converter->convert($node);
+
+    $this->assertStringContainsString('url: "/path/with\\"quote\\\\back"', $output);
+  }
+
+  /**
+   * GenerateFullText() must use accessCheck(TRUE) on the entity query.
+   *
+   * This is the core access-control fix: previously the method ran a raw
+   * DB join that bypassed node access. The PR replaced it with an entity
+   * query that respects node grants.
+   *
+   * @covers ::generateFullText
+   */
+  public function testGenerateFullTextUsesAccessCheck(): void {
+    [$converter] = $this->buildConverterForGenerateFullText(
+      enabledTypes: ['article'],
+      accessibleNids: [],
+    );
+
+    // The expectation is enforced inside buildConverterForGenerateFullText
+    // via accessCheck()->with(TRUE). Reaching here means the query was
+    // configured correctly; this assertion just keeps PHPUnit happy.
+    $output = $converter->generateFullText();
+
+    $this->assertStringStartsWith('# Site', $output);
+    // No content section when access-filtered nids is empty.
+    $this->assertStringNotContainsString("---\n\n", $output);
+  }
+
+  /**
+   * GenerateFullText() returns site header only when no enabled types set.
+   *
+   * @covers ::generateFullText
+   */
+  public function testGenerateFullTextWithNoEnabledTypesShortCircuits(): void {
+    [$converter] = $this->buildConverterForGenerateFullText(
+      enabledTypes: [],
+      accessibleNids: [],
+      expectEntityQuery: FALSE,
+    );
+
+    $output = $converter->generateFullText();
+
+    $this->assertSame("# Site\n\n", $output);
+  }
+
+  /**
+   * GenerateFullText() concatenates only stored markdown for accessible nids.
+   *
+   * @covers ::generateFullText
+   */
+  public function testGenerateFullTextOnlyFetchesAccessibleNids(): void {
+    [$converter] = $this->buildConverterForGenerateFullText(
+      enabledTypes: ['article'],
+      accessibleNids: [10, 20],
+      storedMarkdown: ['# Ten body', '# Twenty body'],
+    );
+
+    $output = $converter->generateFullText();
+
+    $this->assertStringContainsString('# Ten body', $output);
+    $this->assertStringContainsString('# Twenty body', $output);
+    $this->assertStringContainsString("\n\n---\n\n", $output);
+  }
+
+  /**
+   * Builds a converter wired for generateFullText() with mock expectations.
+   *
+   * @param string[] $enabledTypes
+   *   The enabled content type machine names.
+   * @param int[] $accessibleNids
+   *   The nids the entity query (with accessCheck) should return.
+   * @param string[] $storedMarkdown
+   *   The markdown rows the follow-up SELECT should return.
+   * @param bool $expectEntityQuery
+   *   Whether the entity query should be invoked. FALSE when enabledTypes
+   *   is empty and the method short-circuits.
+   *
+   * @return array{MarkdownConverter, \PHPUnit\Framework\MockObject\MockObject}
+   *   The converter and the database mock.
+   */
+  protected function buildConverterForGenerateFullText(
+    array $enabledTypes,
+    array $accessibleNids,
+    array $storedMarkdown = [],
+    bool $expectEntityQuery = TRUE,
+  ): array {
+    $reflection = new \ReflectionClass(MarkdownConverter::class);
+    $converter = $reflection->newInstanceWithoutConstructor();
+
+    // configFactory: enabled_content_types + system.site.
+    $llmSettings = $this->createMock(ImmutableConfig::class);
+    $llmSettings->method('get')->willReturnCallback(
+      static fn (string $k) => match ($k) {
+        'enabled_content_types' => $enabledTypes,
+        default => NULL,
+      },
+    );
+    $siteSettings = $this->createMock(ImmutableConfig::class);
+    $siteSettings->method('get')->willReturnCallback(
+      static fn (string $k) => match ($k) {
+        'name' => 'Site',
+        default => '',
+      },
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturnCallback(
+      static fn (string $name) => $name === 'system.site' ? $siteSettings : $llmSettings,
+    );
+    $this->setProp($reflection, $converter, 'configFactory', $configFactory);
+
+    // entityTypeManager + storage + entity query.
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    if ($expectEntityQuery) {
+      $query = $this->createMock(QueryInterface::class);
+      $query->method('condition')->willReturnSelf();
+      $query->method('sort')->willReturnSelf();
+      // Strict: accessCheck must be called with TRUE.
+      $query->expects($this->atLeastOnce())
+        ->method('accessCheck')
+        ->with(TRUE)
+        ->willReturnSelf();
+      $query->method('execute')->willReturn($accessibleNids);
+
+      $storage = $this->createMock(EntityStorageInterface::class);
+      $storage->method('getQuery')->willReturn($query);
+      $etm->method('getStorage')->with('node')->willReturn($storage);
+    }
+    else {
+      $etm->expects($this->never())->method('getStorage');
+    }
+    $this->setProp($reflection, $converter, 'entityTypeManager', $etm);
+
+    // database->select() chain — only invoked when accessibleNids is non-empty.
+    $database = $this->createMock(Connection::class);
+    if (!empty($accessibleNids)) {
+      $statement = $this->createMock(StatementInterface::class);
+      $statement->method('fetchCol')->willReturn($storedMarkdown);
+
+      $select = $this->createMock(SelectInterface::class);
+      $select->method('fields')->willReturnSelf();
+      $select->method('condition')->willReturnSelf();
+      $select->method('orderBy')->willReturnSelf();
+      $select->method('execute')->willReturn($statement);
+
+      $database->expects($this->once())
+        ->method('select')
+        ->with('llm_content_markdown', 'm')
+        ->willReturn($select);
+    }
+    else {
+      $database->expects($this->never())->method('select');
+    }
+    $this->setProp($reflection, $converter, 'database', $database);
+
+    return [$converter, $database];
+  }
+
+}

--- a/tests/src/Unit/MarkdownConverterSecurityTest.php
+++ b/tests/src/Unit/MarkdownConverterSecurityTest.php
@@ -162,6 +162,54 @@ class MarkdownConverterSecurityTest extends TestCase {
   }
 
   /**
+   * Markdown brackets in titles must not appear verbatim in the H1.
+   *
+   * Without sanitization, a title of `[click](javascript:alert(1))` lands
+   * verbatim in the H1 and renders as a malicious link when consumers
+   * convert the markdown back to HTML. The fix replaces `[`/`]` with
+   * `(`/`)` — same defense the llms.txt link title uses.
+   *
+   * @covers ::convert
+   */
+  public function testConvertReplacesBracketsInHeadingTitle(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      label: '[click](javascript:alert(1))',
+    );
+
+    $output = $converter->convert($node);
+
+    // Brackets in the heading have been neutralized.
+    $this->assertMatchesRegularExpression(
+      '/^# \(click\)\(javascript:alert\(1\)\)\n/m',
+      $output,
+    );
+    $this->assertStringNotContainsString('# [click]', $output);
+  }
+
+  /**
+   * Control characters in titles must be stripped from the H1.
+   *
+   * A newline in the title would break the markdown H1 line and could
+   * inject additional headings or arbitrary content.
+   *
+   * @covers ::convert
+   */
+  public function testConvertStripsControlCharsFromHeadingTitle(): void {
+    [$converter, $node] = $this->buildConverterForConvert(
+      label: "Innocent\n## Injected H2",
+    );
+
+    $output = $converter->convert($node);
+
+    // The newline is gone, so no second-level heading can be injected.
+    $this->assertMatchesRegularExpression(
+      '/^# Innocent## Injected H2\n/m',
+      $output,
+    );
+    $this->assertDoesNotMatchRegularExpression('/^## Injected H2$/m', $output);
+  }
+
+  /**
    * Double quotes and backslashes in titles must be YAML-escaped.
    *
    * Without escaping, a title containing `"` breaks the YAML
@@ -376,6 +424,17 @@ class MarkdownConverterSecurityTest extends TestCase {
       $select->method('condition')->willReturnSelf();
       $select->method('orderBy')->willReturnSelf();
       $select->method('execute')->willReturn($statement);
+      // Asserts the canonical-translation join was added on top of the
+      // access-check fix — otherwise multilingual sites would emit one
+      // copy of the same node per stored language.
+      $select->expects($this->once())
+        ->method('innerJoin')
+        ->with(
+          'node_field_data',
+          'n',
+          $this->stringContains('n.langcode = m.langcode'),
+        )
+        ->willReturnSelf();
 
       $database->expects($this->once())
         ->method('select')


### PR DESCRIPTION
## Summary

Addresses security issues identified during code review of the llm_content module:

- **Broken access control** in `generateFullText()`: Replaced direct DB query with entity query using `accessCheck(TRUE)` to enforce node access restrictions on `/llms-full.txt`. Also removed the hardcoded 500-item limit.
- **XSS via node titles**: Added `strip_tags()` on `$node->label()` before inserting into markdown H1 headings and YAML frontmatter title fields.
- **YAML frontmatter injection**: Path aliases are now quoted and sanitized (control chars stripped, quotes escaped) to prevent newline-based YAML injection.
- **Markdown link injection**: Node titles in `[title](url)` links in `llms.txt` are sanitized with `strip_tags()` and `[`/`]` replaced to prevent breaking markdown link syntax.
- **Cache context leakage**: Added `user.node_grants:view` cache context to all endpoints (sitemap, llms.txt, llms-full.txt) that use `accessCheck(TRUE)` entity queries, preventing cached responses from leaking restricted content across users.

## Files changed
- `src/Service/MarkdownConverter.php` — access control, XSS, YAML injection fixes
- `src/Controller/LlmsTxtController.php` — markdown injection, cache context fixes
- `src/Controller/LlmSitemapController.php` — cache context fix

## Test plan
- [ ] All existing unit tests still pass
- [ ] PHPCS/PHPStan clean
- [ ] `/llms-full.txt` respects node access restrictions
- [ ] Node titles with HTML tags are stripped in markdown output
- [ ] Path aliases with special characters are safely quoted in YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)